### PR TITLE
fix(lineWidth) center timeline when having different line width

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,8 +74,21 @@ type State = {
 class Timeline extends React.Component<Props, State> {
   state = {
     x: 0,
-    width: 0
+    width: 0,
+    maxLineWidth: DEFAULT_LINE_WIDTH,
   };
+
+  static getDerivedStateFromProps (props, state) {
+    let maxLineWidth = props.lineWidth || DEFAULT_LINE_WIDTH
+
+    (props.data || []).forEach(function (item) {
+      maxLineWidth = Math.max(maxLineWidth, item.lineWidth || maxLineWidth)
+    })
+
+    return {
+      ...state,
+    }
+  }
 
   render() {
     const { style, data, flatListStyle, flatListProps, keyExtractor } = this.props;
@@ -223,6 +236,7 @@ class Timeline extends React.Component<Props, State> {
 
     const lineColorToUse = item.lineColor || lineColor || DEFAULT_LINE_COLOR;
     const lineWidthToUse = item.lineWidth || lineWidth || DEFAULT_LINE_WIDTH;
+    const marginDelta = Math.floor((this.state.maxLineWidth - lineWidthToUse) / 2.0);
 
     const isLast = renderFullLine ? !renderFullLine : index + 1 === data.length;
     const borderColor = isLast ? 'transparent' : lineColorToUse;
@@ -235,8 +249,8 @@ class Timeline extends React.Component<Props, State> {
           borderColor: borderColor,
           borderLeftWidth: lineWidthToUse,
           borderRightWidth: 0,
-          marginLeft: 20,
-          paddingLeft: 20
+          marginLeft: 20 + marginDelta,
+          paddingLeft: 20 + marginDelta
         };
         break;
       case 'single-column-right':
@@ -244,8 +258,8 @@ class Timeline extends React.Component<Props, State> {
           borderColor: borderColor,
           borderLeftWidth: 0,
           borderRightWidth: lineWidthToUse,
-          marginRight: 20,
-          paddingRight: 20
+          marginRight: 20 + marginDelta,
+          paddingRight: 20 + marginDelta
         };
         break;
       case 'two-column':
@@ -255,15 +269,15 @@ class Timeline extends React.Component<Props, State> {
                 borderColor: borderColor,
                 borderLeftWidth: lineWidthToUse,
                 borderRightWidth: 0,
-                marginLeft: 20,
-                paddingLeft: 20
+                marginLeft: 20 + marginDelta,
+                paddingLeft: 20 + marginDelta
               }
             : {
                 borderColor: borderColor,
                 borderLeftWidth: 0,
                 borderRightWidth: lineWidthToUse,
-                marginRight: 20,
-                paddingRight: 20
+                marginRight: 20 + marginDelta,
+                paddingRight: 20 + marginDelta
               };
         break;
     }


### PR DESCRIPTION
Use case:

```
const data = [
      {key: 1, title: '123 Napier Road', description: 'Walk 400 m (1 min)'},
      {key: 2, time: 'at 1:09 PM', title: 'St Patrick', description: '2 stops  (20 min)', lineColor: LIGHT_BLUE, circleColor: LIGHT_BLUE, dotColor: WHITE, lineWidth: 12 },
      {key: 3, time: 'at 2:09 PM', title: 'Toronto Eaton Centre', description: '2 stops  (20 min)', lineColor: BLUE, circleColor: BLUE, dotColor: WHITE, lineWidth: 12 },
      {key: 4, title: 'Union Station', description: 'Walk 100 m (1 min)'},
      {key: 5, title: 'Auckland ', description: 'Auckland'},
    ]

<Timeline
            data={data}

            circleSize={18}
            circleColor={TRANSPARENT}
            innerCircleType="dot"
            dotColor={DARK_GRAY}

            lineColor={GRAY}
            lineWidth={1}

            timeContainerStyle={{
              width: 70,
            }}
            timeStyle={{
              textAlign: 'center',
              paddingTop: 10,
            }}

            titleStyle={{
              top: -30,
            }}
            descriptionStyle={{
              color: 'gray',
              top: -30,
            }}

            flatListProps={{
              style: {
                paddingTop: 50,
              }
            }}

            endWithCircle
            renderFullLine

            keyExtractor={item => `row${item.key}`}

          />
```

When having different line width the timeline is not centered:

<img width="311" alt="schermata 2019-02-05 alle 11 02 36" src="https://user-images.githubusercontent.com/579163/52240463-c06ec080-2935-11e9-9111-5e3bfce60645.png">

After this fix, it looks like this:

<img width="313" alt="schermata 2019-02-05 alle 10 57 28" src="https://user-images.githubusercontent.com/579163/52240482-ccf31900-2935-11e9-9468-5933e650e081.png">
